### PR TITLE
MRLP-12: 공통 응답 포맷 구현

### DIFF
--- a/src/main/java/com/goorm/BITA/TestController.java
+++ b/src/main/java/com/goorm/BITA/TestController.java
@@ -1,5 +1,6 @@
 package com.goorm.BITA;
 
+import com.goorm.BITA.api.ApiFormat;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,5 +43,10 @@ public class TestController {
         @RequestBody TestRequestDto testRequestDto
     ) {
         return new TestResponseDto(testRequestDto.getMessage(), testId);
+    }
+
+    @GetMapping("/test3")
+    public ApiFormat<TestResponseDto> test3 () {
+        return ApiFormat.successResponse(new TestResponseDto("test3", 3));
     }
 }

--- a/src/main/java/com/goorm/BITA/api/ApiFormat.java
+++ b/src/main/java/com/goorm/BITA/api/ApiFormat.java
@@ -1,0 +1,53 @@
+package com.goorm.BITA.api;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiFormat<T> {
+    private String status; // 추후에 enum으로 변경
+    private T data;
+    private String message;
+
+    private ApiFormat(String status, T data, String message) {
+        this.status = status;
+        this.data = data;
+        this.message = message;
+    }
+    public static <T> ApiFormat<T> successResponse(T data) {
+        // TODO: status를 enum으로 변경
+        return new ApiFormat<>("success", data, null);
+    }
+
+    public static ApiFormat<?> successWithoutDataResponse() {
+        // TODO: status를 enum으로 변경
+        return new ApiFormat<>("success", null, null);
+    }
+
+    public static ApiFormat<?> errorResponse(String message) {
+        // TODO: status를 enum으로 변경
+        return new ApiFormat<>("error", null, message);
+    }
+
+    public static ApiFormat<?> failResponse(BindingResult bindingResult) {
+        Map<String, String> errors = new HashMap<>();
+
+        bindingResult.getAllErrors().forEach(error -> {
+            if (error instanceof FieldError) {
+                FieldError fieldError = (FieldError) error;
+                errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+            } else {
+                errors.put(error.getObjectName(), error.getDefaultMessage());
+            }
+        });
+        // TODO: status를 enum으로 변경
+        return new ApiFormat<>("fail", errors, null);
+    }
+}


### PR DESCRIPTION
공통 응답 포맷 구현했습니다
enum 부분은 임시로 string 값으로 넣어놨어요. 추후에 수정이 필요합니다!
swagger의 ApiResponse 어노테이션과 이름이 중복되어서 ApiFormat으로 우선 클래스 이름을 지어놨습니다